### PR TITLE
Fix setupFilesAfterEnv path in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Add to your `jest` key in `package.json`.
 ```json
 "jest": {
   "preset": "react-native",
-  "setupFilesAfterEnv": ["./node_modules/riteway-jest/src/riteway-jest.js"]
+  "setupFilesAfterEnv": ["<rootDir>/node_modules/riteway-jest/src/riteway-jest.js"]
 }
 ```
 
@@ -59,7 +59,7 @@ Add to your `jest` key in `package.json`.
 ```json
 "jest": {
   "preset": "jest-expo",
-  "setupFilesAfterEnv": ["./node_modules/riteway-jest/src/riteway-jest.js"]
+  "setupFilesAfterEnv": ["<rootDir>/node_modules/riteway-jest/src/riteway-jest.js"]
 }
 ```
 
@@ -68,7 +68,7 @@ Add to your `jest` key in `package.json`.
 ```js
 module.exports = {
   setupFilesAfterEnv: [
-    './node_modules/riteway-jest/src/riteway-jest.js',
+    '<rootDir>/node_modules/riteway-jest/src/riteway-jest.js',
     // ... other setup files ...
   ],
   // ... other options ...

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Add to your `jest` key in `package.json`.
 ```json
 "jest": {
   "preset": "react-native",
-  "setupFilesAfterEnv": ["node_modules/riteway-jest/src/riteway-jest.js"]
+  "setupFilesAfterEnv": ["./node_modules/riteway-jest/src/riteway-jest.js"]
 }
 ```
 
@@ -59,7 +59,7 @@ Add to your `jest` key in `package.json`.
 ```json
 "jest": {
   "preset": "jest-expo",
-  "setupFilesAfterEnv": ["node_modules/riteway-jest/src/riteway-jest.js"]
+  "setupFilesAfterEnv": ["./node_modules/riteway-jest/src/riteway-jest.js"]
 }
 ```
 
@@ -68,7 +68,7 @@ Add to your `jest` key in `package.json`.
 ```js
 module.exports = {
   setupFilesAfterEnv: [
-    'node_modules/riteway-jest/src/riteway-jest.js',
+    './node_modules/riteway-jest/src/riteway-jest.js',
     // ... other setup files ...
   ],
   // ... other options ...


### PR DESCRIPTION
Hey, using node_modules..etc without a preceeding `./` gave me an error so I thought I'd raise PR in case it catches anyone else out

Edit: switched to `<rootDir>` instead as it's more reliable